### PR TITLE
Add robust babel support

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -10,10 +10,10 @@ else {
 
     try {
         require('babel-register');
-    } catch() {
+    } catch(e) {
         try {
             require('babel/register');
-        } catch() {}
+        } catch(e) {}
     }
 }
 

--- a/bin/run.js
+++ b/bin/run.js
@@ -1,7 +1,22 @@
 #!/usr/bin/env node
 
-var call = require('../lib/index').call;
-require("babel/register");
+var config = require('pkg-config')('runjs');
+var call   = require('../lib/index').call;
+
+if (config && config['require-hook']) {
+  require(config['require-hook']);
+}
+else {
+
+    try {
+        require('babel-register');
+    } catch() {
+        try {
+            require('babel/register');
+        } catch() {}
+    }
+}
+
 try {
     var runfile = require(process.cwd() + '/runfile');
     call(runfile, process.argv.slice(2));

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "chalk": "1.1.0",
     "chokidar": "1.2.0",
     "lodash": "3.10.1",
-    "pkg-config": "^1.1.0"
+    "pkg-config": "1.1.0"
   },
   "devDependencies": {
     "babel": "5.8.23",

--- a/package.json
+++ b/package.json
@@ -26,12 +26,13 @@
   },
   "homepage": "https://github.com/pawelgalazka/runjs#readme",
   "dependencies": {
-    "babel": "5.8.23",
     "chalk": "1.1.0",
     "chokidar": "1.2.0",
-    "lodash": "3.10.1"
+    "lodash": "3.10.1",
+    "pkg-config": "^1.1.0"
   },
   "devDependencies": {
+    "babel": "5.8.23",
     "mocha": "2.3.4",
     "mochaccino": "1.1.0"
   }


### PR DESCRIPTION
This PR has three main parts. 

- Runjs no longer includes babel as a direct dependency. If a user wants to use ES6, they need to install babel. This let's the user choose which version of babel to use if any. 
- A user can now use a custom require hook in their package.json to register a different transpiler.

```javascript
// package.json
{
  "config": {
    "runjs": {
       "require-hook": "coffee-script/register"
    }
  }
}
```

- If the user has babel installed and doesn't specify a require hook then it will automatically try to register the babel require hook. This lets users still use babel without having to do anything special aside from install it. 