### PR TITLE
v3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ run given command as a child process and log the call in the output.
 {
     cwd: ..., // current working directory (String)
     async: ... // run command asynchronously (true/false), false by default
-    stdio: ... // 'inherit' (default) or 'pipe' (String)
+    stdio: ... // 'inherit' (default), 'pipe' or 'ignore'
     env: ... // environment key-value pairs (Object)
     timeout: ...
 }
@@ -155,14 +155,22 @@ run given command as a child process and log the call in the output.
 
 *Examples:*
 
+To get an output from `run` function we need to set `stdio` option to `pipe` otherwise
+`output` will be `null`:
+
 ```javascript
-run('rm -rf ./build')
-run('http-server .', {async: true}).then((output) => {
+const output = run('ls -la', {stdio: 'pipe'})
+run('http-server .', {async: true, stdio: 'pipe'}).then((output) => {
   log(output) 
 }).catch((error) => {
   throw error
 })
 ```
+
+For `stdio: 'pipe'` outputs are returned but not forwarded to the parent process thus 
+not printed out to the terminal. For `stdio: 'inherit'` (default) outputs are passed 
+to the terminal, but `run` function will resolve (async) / return (sync)
+`null`.
 
 #### generate(src, dst, context)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runjs",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Minimalistic building tool",
   "keywords": [
     "build",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "homepage": "https://github.com/pawelgalazka/runjs#readme",
   "dependencies": {
     "chalk": "1.1.3",
+    "get-parameter-names": "0.3.0",
     "lodash.template": "4.4.0"
   },
   "devDependencies": {

--- a/src/script.js
+++ b/src/script.js
@@ -80,14 +80,13 @@ function parseArgs (args) {
 
 export function describe (obj, logger, namespace) {
   if (!namespace) {
-    logger.log('Available tasks:')
+    logger.debug('Available tasks:')
   }
 
   Object.keys(obj).forEach((key) => {
     const value = obj[key]
     const nextNamespace = namespace ? `${namespace}:${key}` : key
     const doc = value.doc
-    const loggerParams = [nextNamespace]
 
     if (typeof value === 'function') {
       let funcParams
@@ -96,13 +95,11 @@ export function describe (obj, logger, namespace) {
       } catch (error) {
         funcParams = []
       }
-      if (funcParams.length) {
-        loggerParams.push(`[${funcParams.join(' ')}]`)
-      }
+      const paramsDoc = funcParams.length ? `[${funcParams.join(' ')}]` : ''
+      logger.info('\n', nextNamespace, paramsDoc)
       if (doc) {
-        loggerParams.push(`- ${doc}`)
+        logger.log(`   ${doc}`)
       }
-      logger.log(...loggerParams)
     } else if (typeof value === 'object') {
       describe(value, logger, nextNamespace)
     }

--- a/src/script.js
+++ b/src/script.js
@@ -1,6 +1,7 @@
 import path from 'path'
 import fs from 'fs'
 import { RunJSError } from './common'
+import getParamNames from 'get-parameter-names'
 
 export function requirer (filePath) {
   return require(path.resolve(filePath))
@@ -84,15 +85,24 @@ export function describe (obj, logger, namespace) {
 
   Object.keys(obj).forEach((key) => {
     const value = obj[key]
-    const doc = value.doc
     const nextNamespace = namespace ? `${namespace}:${key}` : key
+    const doc = value.doc
+    const loggerParams = [nextNamespace]
 
     if (typeof value === 'function') {
-      if (doc) {
-        logger.log(nextNamespace, `- ${doc}`)
-      } else {
-        logger.log(nextNamespace)
+      let funcParams
+      try {
+        funcParams = getParamNames(value)
+      } catch (error) {
+        funcParams = []
       }
+      if (funcParams.length) {
+        loggerParams.push(`[${funcParams.join(' ')}]`)
+      }
+      if (doc) {
+        loggerParams.push(`- ${doc}`)
+      }
+      logger.log(...loggerParams)
     } else if (typeof value === 'object') {
       describe(value, logger, nextNamespace)
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -19,37 +19,77 @@ describe('api', () => {
 
   describe('run()', () => {
     describe('sync version', () => {
-      it('should execute basic shell commands', () => {
-        const output = api.run('echo "echo test"', {cwd: './test/sandbox'}, logger)
-        expect(output).toEqual('echo test\n')
-        expect(logger.info).toHaveBeenCalledWith('echo "echo test"')
+      describe('with stdio=pipe', () => {
+        it('should execute basic shell commands', () => {
+          const output = api.run('echo "echo test"', {stdio: 'pipe'}, logger)
+          expect(output).toEqual('echo test\n')
+          expect(logger.info).toHaveBeenCalledWith('echo "echo test"')
+        })
+
+        it('should throw an error if command fails', () => {
+          expect(() => {
+            api.run('node ./ghost.js', {stdio: 'pipe'}, logger)
+          }).toThrow(RunJSError)
+        })
+
+        it('should have access to environment variables by default', () => {
+          const output = api.run('echo $RUNJS_TEST', {stdio: 'pipe'}, logger)
+          expect(output).toEqual('runjs test\n')
+        })
       })
 
-      it('should throw an error if command fails', () => {
-        expect(() => {
-          api.run('node ./ghost.js', {stdio: 'pipe'}, logger)
-        }).toThrow(RunJSError)
-      })
+      describe('with stdio=inherit', () => {
+        it('should execute basic shell commands', () => {
+          const output = api.run('echo "echo test"', {}, logger)
+          expect(output).toEqual(null)
+          expect(logger.info).toHaveBeenCalledWith('echo "echo test"')
+        })
 
-      it('should have access to environment variables by default', () => {
-        const output = api.run('echo $RUNJS_TEST', {}, logger)
-        expect(output).toEqual('runjs test\n')
+        it('should throw an error if command fails', () => {
+          expect(() => {
+            api.run('node ./ghost.js', {}, logger)
+          }).toThrow(RunJSError)
+        })
+
+        it('should have access to environment variables by default', () => {
+          const output = api.run('echo $RUNJS_TEST', {}, logger)
+          expect(output).toEqual(null)
+        })
       })
     })
 
     describe('async version', () => {
-      it('should execute basic shell commands', (done) => {
-        api.run('echo "echo test"', {async: true}, logger).then((output) => {
-          expect(output).toEqual('echo test\n')
-          expect(logger.info).toHaveBeenCalledWith('echo "echo test"')
-          done()
+      describe('with stdio=pipe', () => {
+        it('should execute basic shell commands', (done) => {
+          api.run('echo "echo test"', {async: true, stdio: 'pipe'}, logger).then((output) => {
+            expect(output).toEqual('echo test\n')
+            expect(logger.info).toHaveBeenCalledWith('echo "echo test"')
+            done()
+          })
+        })
+
+        it('should have access to environment variables by default', (done) => {
+          api.run('echo $RUNJS_TEST', {async: true, stdio: 'pipe'}, logger).then((output) => {
+            expect(output).toEqual('runjs test\n')
+            done()
+          })
         })
       })
 
-      it('should have access to environment variables by default', (done) => {
-        api.run('echo $RUNJS_TEST', {async: true}, logger).then((output) => {
-          expect(output).toEqual('runjs test\n')
-          done()
+      describe('with stdio=inherit', () => {
+        it('should execute basic shell commands', (done) => {
+          api.run('echo "echo test"', {async: true}, logger).then((output) => {
+            expect(output).toEqual(null)
+            expect(logger.info).toHaveBeenCalledWith('echo "echo test"')
+            done()
+          })
+        })
+
+        it('should have access to environment variables by default', (done) => {
+          api.run('echo $RUNJS_TEST', {async: true}, logger).then((output) => {
+            expect(output).toEqual(null)
+            done()
+          })
         })
       })
     })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -74,6 +74,13 @@ describe('api', () => {
             done()
           })
         })
+
+        it('should reject with an error if command fails', (done) => {
+          api.run('node ./ghost.js', {async: true, stdio: 'pipe'}, logger).catch((error) => {
+            expect(error.message).toEqual('Command failed: node ./ghost.js with exit code 1')
+            done()
+          })
+        })
       })
 
       describe('with stdio=inherit', () => {
@@ -88,6 +95,13 @@ describe('api', () => {
         it('should have access to environment variables by default', (done) => {
           api.run('echo $RUNJS_TEST', {async: true}, logger).then((output) => {
             expect(output).toEqual(null)
+            done()
+          })
+        })
+
+        it('should reject with an error if command fails', (done) => {
+          api.run('node ./ghost.js', {async: true}, logger).catch((error) => {
+            expect(error.message).toEqual('Command failed: node ./ghost.js with exit code 1')
             done()
           })
         })

--- a/test/script.test.js
+++ b/test/script.test.js
@@ -145,20 +145,23 @@ describe('script', () => {
 
     it('should log list of methods available in the object', () => {
       script.describe(obj, logger)
-      expect(logger.log).toHaveBeenCalledTimes(3)
-      expect(logger.log).toHaveBeenCalledWith('Available tasks:')
-      expect(logger.log).toHaveBeenCalledWith('a')
-      expect(logger.log).toHaveBeenCalledWith('b')
+      expect(logger.debug).toHaveBeenCalledTimes(1)
+      expect(logger.info).toHaveBeenCalledTimes(2)
+      expect(logger.debug).toHaveBeenCalledWith('Available tasks:')
+      expect(logger.info).toHaveBeenCalledWith('\n', 'a', '')
+      expect(logger.info).toHaveBeenCalledWith('\n', 'b', '')
     })
 
     it('should log list of methods from the object with description for each one if provided', () => {
       obj.a.doc = 'Description for method a'
       obj.b.doc = 'Description for method b'
       script.describe(obj, logger)
-      expect(logger.log).toHaveBeenCalledWith('Available tasks:')
-      expect(logger.log).toHaveBeenCalledWith('a', '- Description for method a')
-      expect(logger.log).toHaveBeenCalledWith('b', '- Description for method b')
-      expect(logger.log).toHaveBeenCalledTimes(3)
+      expect(logger.debug).toHaveBeenCalledWith('Available tasks:')
+      expect(logger.info).toHaveBeenCalledWith('\n', 'a', '')
+      expect(logger.log).toHaveBeenCalledWith('   Description for method a')
+      expect(logger.info).toHaveBeenCalledWith('\n', 'b', '')
+      expect(logger.log).toHaveBeenCalledWith('   Description for method b')
+      expect(logger.info).toHaveBeenCalledTimes(2)
     })
 
     it('should log list of name spaced / nested methods', () => {
@@ -174,13 +177,14 @@ describe('script', () => {
       obj.c.e.f.doc = 'Description for method f'
 
       script.describe(obj, logger)
-      expect(logger.log).toHaveBeenCalledWith('Available tasks:')
-      expect(logger.log).toHaveBeenCalledWith('a')
-      expect(logger.log).toHaveBeenCalledWith('b')
-      expect(logger.log).toHaveBeenCalledWith('c:d')
-      expect(logger.log).toHaveBeenCalledWith('c:e:f', '- Description for method f')
-      expect(logger.log).toHaveBeenCalledWith('c:e:g')
-      expect(logger.log).toHaveBeenCalledTimes(6)
+      expect(logger.debug).toHaveBeenCalledWith('Available tasks:')
+      expect(logger.info).toHaveBeenCalledWith('\n', 'a', '')
+      expect(logger.info).toHaveBeenCalledWith('\n', 'b', '')
+      expect(logger.info).toHaveBeenCalledWith('\n', 'c:d', '')
+      expect(logger.info).toHaveBeenCalledWith('\n', 'c:e:f', '')
+      expect(logger.log).toHaveBeenCalledWith('   Description for method f')
+      expect(logger.info).toHaveBeenCalledWith('\n', 'c:e:g', '')
+      expect(logger.info).toHaveBeenCalledTimes(5)
     })
   })
 


### PR DESCRIPTION
- [x] documenting tasks args when calling `run` without arguments
- [x] presenting list of available tasks from `runfile.js` in more readable way
- [x] passing `stdio` directly to spawn/execSync
- [x] changing `run` api where now it resolves/returns null by default and resolves/returns with value for option `stdio: 'pipe'`. This allows to return colours to the terminal if provided by commands outcome.