### PR TITLE
V3.1.1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ export function run (command, options = {}, logger = loggerAlias) {
 
   // Pick relevant option keys and set default values
   options = {
-    env: options.env || {},
+    env: options.env || process.env,
     cwd: options.cwd,
     async: !!options.async,
     stdio: options.stdio || 'inherit',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,8 @@
 import * as api from '../lib/index'
 import { RunJSError } from '../lib/common'
 
+process.env.RUNJS_TEST = 'runjs test'
+
 describe('api', () => {
   let logger
 
@@ -28,6 +30,11 @@ describe('api', () => {
           api.run('node ./ghost.js', {stdio: 'pipe'}, logger)
         }).toThrow(RunJSError)
       })
+
+      it('should have access to environment variables by default', () => {
+        const output = api.run('echo $RUNJS_TEST', {}, logger)
+        expect(output).toEqual('runjs test\n')
+      })
     })
 
     describe('async version', () => {
@@ -35,6 +42,13 @@ describe('api', () => {
         api.run('echo "echo test"', {async: true}, logger).then((output) => {
           expect(output).toEqual('echo test\n')
           expect(logger.info).toHaveBeenCalledWith('echo "echo test"')
+          done()
+        })
+      })
+
+      it('should have access to environment variables by default', (done) => {
+        api.run('echo $RUNJS_TEST', {async: true}, logger).then((output) => {
+          expect(output).toEqual('runjs test\n')
           done()
         })
       })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,24 +16,28 @@ describe('api', () => {
   })
 
   describe('run()', () => {
-    it('should execute basic shell commands when sync mode', () => {
-      const output = api.run('echo "echo test"', {cwd: './test/sandbox'}, logger)
-      expect(output).toEqual('echo test\n')
-      expect(logger.info).toHaveBeenCalledWith('echo "echo test"')
-    })
-
-    it('should execute basic shell commands when async mode', (done) => {
-      api.run('echo "echo test"', {async: true}, logger).then((output) => {
+    describe('sync version', () => {
+      it('should execute basic shell commands', () => {
+        const output = api.run('echo "echo test"', {cwd: './test/sandbox'}, logger)
         expect(output).toEqual('echo test\n')
         expect(logger.info).toHaveBeenCalledWith('echo "echo test"')
-        done()
+      })
+
+      it('should throw an error if command fails', () => {
+        expect(() => {
+          api.run('node ./ghost.js', {stdio: 'pipe'}, logger)
+        }).toThrow(RunJSError)
       })
     })
 
-    it('should throw an error if command fails', () => {
-      expect(() => {
-        api.run('node ./ghost.js', {stdio: 'pipe'}, logger)
-      }).toThrow(RunJSError)
+    describe('async version', () => {
+      it('should execute basic shell commands', (done) => {
+        api.run('echo "echo test"', {async: true}, logger).then((output) => {
+          expect(output).toEqual('echo test\n')
+          expect(logger.info).toHaveBeenCalledWith('echo "echo test"')
+          done()
+        })
+      })
     })
   })
 


### PR DESCRIPTION
Fix the bug with passing `process.env`