### PR TITLE
Add support for dashed arguments

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -56,8 +56,8 @@ export function load (runfilePath, config, logger, requirer, access) {
 function parseArgs (args) {
   let options = {}
   let nextArgs = args.filter(arg => {
-    const doubleDashMatch = arg.match(/^--(\w+)=(\w*)$/) || arg.match(/^--(\w+)$/)
-    const singleDashMatch = arg.match(/^-(\w)=(\w*)$/) || arg.match(/^-(\w)$/)
+    const doubleDashMatch = arg.match(/^--([\w-.]+)=([\w-.]*)$/) || arg.match(/^--([\w-.]+)$/)
+    const singleDashMatch = arg.match(/^-(?!-)([\w-.])=([\w-.]*)$/) || arg.match(/^-(?!-)([\w-.])$/)
 
     if (singleDashMatch) {
       options[singleDashMatch[1]] = Number(singleDashMatch[2]) || singleDashMatch[2] || true

--- a/test/script.test.js
+++ b/test/script.test.js
@@ -276,6 +276,8 @@ describe('script', () => {
       expect(a).toHaveBeenLastCalledWith('hello', {a: true, abc: 'test'})
       script.call(obj, ['a', '-a', '--abc=test', '-b=4', 'hello', '-abc', '--def'])
       expect(a).toHaveBeenLastCalledWith('hello', '-abc', {a: true, b: 4, abc: 'test', def: true})
+      script.call(obj, ['a', '--ab-cd', '--ef-gh=test', '--ab.cd', '--ef.gh=123', 'hello', '-abc'])
+      expect(a).toHaveBeenLastCalledWith('hello', '-abc', {'ab-cd': true, 'ef-gh': 'test', 'ab.cd': true, 'ef.gh': 123})
     })
 
     it('should call methods from nested objects by method name name-spacing', () => {


### PR DESCRIPTION
Like a lot of node modules, I'd like to be able to pass dashed arguments like `--skip-tests` to my runjs tasks. This PR allows that.