### PR TITLE
Add validation to help(func). Fixes #88

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,5 +119,11 @@ export function options(thisObj: ?Object): Object {
 }
 
 export function help(func: () => void, annotation?: string | Object) {
-  func.help = annotation
+  // Because the validation above currently gets compiled out,
+  // Explictly  validate the function input
+  if (typeof func === 'function') {
+    func.help = annotation
+  } else {
+    throw new Error('first help() argument must be a function')
+  }
 }

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -199,4 +199,12 @@ describe('api', () => {
       expect(api.options({})).toEqual({})
     })
   })
+
+  describe('help()', () => {
+    it('throws an error if first argument is not a function', () => {
+      expect(() => api.help(undefined)).toThrow(
+        'first help() argument must be a function'
+      )
+    })
+  })
 })


### PR DESCRIPTION
See #88 for more context.

I tested that after the fix was need, `run` produces a useful stacktrace that points to the problem.

The problem was at `runfile.js` like 3, as the stracktrace indicated.

```
Error: first help() argument must be a function
    at help (/path/lib/index.js:127:11)
    at Object.<anonymous> (/path/runfile.js:3:1)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at requirer (/path/node_modules/runjs/lib/script.js:44:10)
```